### PR TITLE
Allow global install and use external modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 .*.swp
 
 Thumbs.db
+
+# cmake build directories
+/build
+/cmake-build*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG of the Unified Image Processing Framework
 Currently under development
 ---------------------------
 
+- Bug: It was not possible to compile and use external modules
 - Enhancement: Added a command to allow listing of all loaded modules `uipf --list`
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Currently under development
 
 - Bug: It was not possible to compile and use external modules
 - Enhancement: Added a command to allow listing of all loaded modules `uipf --list`
+- Enhancement: Added Default and Copy Constructors to the Data types
 
 
 Version 1.0.0-beta, July 11, 2015

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Currently under development
 ---------------------------
 
 - Bug: It was not possible to compile and use external modules
+- Bug: Relative paths did not work in a configuration file, when it was called from another directory
 - Enhancement: Added a command to allow listing of all loaded modules `uipf --list`
 - Enhancement: Added Default and Copy Constructors to the Data types
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,19 @@ mkdir -p code/build
 cd code/build
 cmake ..
 make
+sudo make install
 ```
 
+For a custom installation prefix you may specify it in the `DESTDIR` for the make command, like so:
+`make DESTDIR=/tmp/uipf install`, which will install all uipf files under the directory `/tmp/uipf`.
+
 If something goes wrong you may run `make VERBOSE=1` for more detailed output.
+
 
 ### Building with CMake on Windows
 
 TBD.
+
 
 How to contribute
 -----------------

--- a/code/.gitignore
+++ b/code/.gitignore
@@ -1,1 +1,2 @@
 /build
+/cmake-build*

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -110,8 +110,12 @@ qt5_use_modules(uipf-gui Core Gui Widgets)
 
 
 add_library(uipf-ModuleBase STATIC
-	framework/DataManager.cpp
 	framework/ModuleBase.cpp
+
+	framework/Context.cpp
+	framework/GUIEventDispatcher.cpp
+
+	framework/DataManager.cpp
 	framework/types/Data.cpp
 	framework/types/String.cpp
 	framework/types/Float.cpp
@@ -120,7 +124,7 @@ add_library(uipf-ModuleBase STATIC
 	framework/types/Matrix.cpp
 )
 #add_library(uipf-ModuleBase SHARED framework/ModuleBase.cpp )
-qt5_use_modules(uipf-ModuleBase Core )
+qt5_use_modules(uipf-ModuleBase Core Gui)
 
 
 

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -14,8 +14,11 @@ set(CMAKE_AUTOUIC ON)
 
 #c++11 support
 #if(UNIX)
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -std=gnu++0x")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2 -Wall -std=gnu++0x")
 #endif()
+
+# sanitize memory issues https://gcc.gnu.org/gcc-4.8/changes.html
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fno-omit-frame-pointer")
 
 # find Qt library for building the GUI
 find_package(Qt5Widgets REQUIRED)

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -8,7 +8,7 @@ project(UIPFramework)
 
 # CMake settings
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_BUILD_TYPE Debug)
+#set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTOUIC ON)
 
@@ -109,7 +109,16 @@ target_link_libraries (uipf-gui boost_graph uipf-framework)
 qt5_use_modules(uipf-gui Core Gui Widgets)
 
 
-add_library(uipf-ModuleBase SHARED framework/ModuleBase.cpp )
+add_library(uipf-ModuleBase STATIC
+	framework/ModuleBase.cpp
+	framework/types/Data.cpp
+	framework/types/String.cpp
+	framework/types/Float.cpp
+	framework/types/Integer.cpp
+	framework/types/Bool.cpp
+	framework/types/Matrix.cpp
+)
+#add_library(uipf-ModuleBase SHARED framework/ModuleBase.cpp )
 qt5_use_modules(uipf-ModuleBase Core )
 
 
@@ -185,6 +194,7 @@ target_link_libraries(AddListItemModule opencv_core opencv_imgproc uipf-ModuleBa
 install(TARGETS uipf uipf-gui uipf-ModuleBase
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib
 )
 install(TARGETS
 			AddListItemModule
@@ -202,4 +212,14 @@ install(TARGETS
 
         LIBRARY DESTINATION lib/uipf
 )
-
+#install header files
+file(GLOB headerFilesFramework "${CMAKE_CURRENT_SOURCE_DIR}/framework/*.hpp")
+file(GLOB headerFilesTypes "${CMAKE_CURRENT_SOURCE_DIR}/framework/types/*.hpp")
+install(FILES
+	${headerFilesFramework}
+	DESTINATION include/uipf/framework
+)
+install(FILES
+	${headerFilesTypes}
+	DESTINATION include/uipf/framework/types
+)

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -110,6 +110,7 @@ qt5_use_modules(uipf-gui Core Gui Widgets)
 
 
 add_library(uipf-ModuleBase STATIC
+	framework/DataManager.cpp
 	framework/ModuleBase.cpp
 	framework/types/Data.cpp
 	framework/types/String.cpp

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -228,3 +228,8 @@ install(FILES
 	${headerFilesTypes}
 	DESTINATION include/uipf/framework/types
 )
+install(FILES
+	${CMAKE_CURRENT_SOURCE_DIR}/uipf-gui.desktop
+	${CMAKE_CURRENT_SOURCE_DIR}/uipf.desktop
+	DESTINATION /usr/share/applications
+)

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -21,12 +21,29 @@ set(CMAKE_AUTOUIC ON)
 find_package(Qt5Widgets REQUIRED)
 
 
+
+#
+# external dependencies
+# http://www.cmake.org/cmake/help/v2.8.8/cmake.html#module%3aExternalProject
+#
+
+# yaml-cpp
+ExternalProject_Add(YAML_CPP
+	GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
+	GIT_TAG release-0.5.2
+	TEST_COMMAND ""
+	INSTALL_COMMAND "" # skip install step for yaml-cpp
+)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/YAML_CPP-prefix/src/YAML_CPP/include)
+set(YAML_CPP_LIBRARY ${CMAKE_CURRENT_BINARY_DIR}/YAML_CPP-prefix/src/YAML_CPP-build/libyaml-cpp.a)
+
+
 #
 # Create executeables
 #
 
-# put the core framework into a shard lib
-add_library(uipf-framework SHARED
+# put the core framework into a static lib
+add_library(uipf-framework STATIC
 
 	framework/ModuleManager.cpp
 	framework/Context.cpp
@@ -46,17 +63,16 @@ add_library(uipf-framework SHARED
 
     framework/Utils.cpp
 )
-# we need to set the path to libyaml-cpp.so so it can be found by linker
-set(YAML_CPP_LIBRARY ${CMAKE_BINARY_DIR}/yaml-cpp/lib/libyaml-cpp.so)
-target_link_libraries(uipf-framework opencv_core opencv_imgproc opencv_highgui ${YAML_CPP_LIBRARY})
+target_link_libraries(uipf-framework opencv_core opencv_imgproc ${YAML_CPP_LIBRARY})
 qt5_use_modules(uipf-framework Core Widgets) # Qt is required for loading modules dynamically
+add_dependencies(uipf-framework YAML_CPP)
+
 
 # add one executeable for the console application
 add_executable(uipf
 	main-console.cpp
 )
 target_link_libraries(uipf boost_program_options uipf-framework)
-qt5_use_modules(uipf Core Gui Widgets) # Qt is required for loading modules dynamically
 
 
 
@@ -93,8 +109,10 @@ target_link_libraries (uipf-gui boost_graph uipf-framework)
 qt5_use_modules(uipf-gui Core Gui Widgets)
 
 
-add_library(ModuleBase SHARED framework/ModuleBase.cpp )
-qt5_use_modules(ModuleBase Core )
+add_library(uipf-ModuleBase SHARED framework/ModuleBase.cpp )
+qt5_use_modules(uipf-ModuleBase Core )
+
+
 
 #
 # Dynamic Modules
@@ -103,77 +121,85 @@ qt5_use_modules(ModuleBase Core )
 # dummy
 add_library(DummyModule SHARED modules/dummy/DummyModule.cpp)
 qt5_use_modules(DummyModule Core ) #QtCore is needed for <QPlugin>
-target_link_libraries(DummyModule ModuleBase)
+target_link_libraries(DummyModule uipf-ModuleBase)
 
 add_library(LongRunningDummyModule SHARED modules/dummy/LongRunningDummyModule.cpp)
 qt5_use_modules(LongRunningDummyModule Core ) #QtCore is needed for <QPlugin>
-target_link_libraries(LongRunningDummyModule ModuleBase)
+target_link_libraries(LongRunningDummyModule uipf-ModuleBase)
 
 # I/O
 add_library(LoadImageModule SHARED modules/io/LoadImageModule.cpp)
 qt5_use_modules(LoadImageModule Core ) #QtCore is needed for <QPlugin>
-target_link_libraries(LoadImageModule opencv_core ModuleBase)
+target_link_libraries(LoadImageModule opencv_core uipf-ModuleBase)
 
 add_library(StoreImageModule SHARED modules/io/StoreImageModule.cpp)
 qt5_use_modules(StoreImageModule Core ) #QtCore is needed for <QPlugin>
-target_link_libraries(StoreImageModule opencv_core ModuleBase)
+target_link_libraries(StoreImageModule opencv_core uipf-ModuleBase)
 
 add_library(ShowImageModule SHARED modules/io/ShowImageModule.cpp)
 qt5_use_modules(ShowImageModule Core ) #QtCore is needed for <QPlugin>
-target_link_libraries(ShowImageModule opencv_core opencv_imgproc opencv_highgui ModuleBase)
+target_link_libraries(ShowImageModule opencv_core opencv_imgproc opencv_highgui uipf-ModuleBase)
 
 add_library(ShowImageListModule SHARED modules/io/ShowImageListModule.cpp)
 qt5_use_modules(ShowImageListModule Core ) #QtCore is needed for <QPlugin>
-target_link_libraries(ShowImageListModule opencv_core opencv_imgproc opencv_highgui ModuleBase)
+target_link_libraries(ShowImageListModule opencv_core opencv_imgproc opencv_highgui uipf-ModuleBase)
 
 # Image Processing
 add_library(GaussianModule SHARED modules/improc/GaussianModule.cpp)
 qt5_use_modules(GaussianModule Core ) #QtCore is needed for <QPlugin>
-target_link_libraries(GaussianModule opencv_core opencv_imgproc ModuleBase)
+target_link_libraries(GaussianModule opencv_core opencv_imgproc uipf-ModuleBase)
 
 #for live demo...
 #add_library(ResizeModule SHARED modules/improc/ResizeModule.cpp)
 #qt5_use_modules(ResizeModule Core ) #QtCore is needed for <QPlugin>
-#target_link_libraries(ResizeModule opencv_core opencv_imgproc ModuleBase)
+#target_link_libraries(ResizeModule opencv_core opencv_imgproc uipf-ModuleBase)
 
 add_library(ConvolutionModule SHARED modules/improc/ConvolutionModule.cpp)
 qt5_use_modules(ConvolutionModule Core ) #QtCore is needed for <QPlugin>
-target_link_libraries(ConvolutionModule opencv_core opencv_imgproc ModuleBase)
+target_link_libraries(ConvolutionModule opencv_core opencv_imgproc uipf-ModuleBase)
 
 add_library(SplitChannelsModule SHARED modules/improc/SplitChannelsModule.cpp)
 qt5_use_modules(SplitChannelsModule Core ) #QtCore is needed for <QPlugin>
-target_link_libraries(SplitChannelsModule opencv_core opencv_imgproc ModuleBase)
+target_link_libraries(SplitChannelsModule opencv_core opencv_imgproc uipf-ModuleBase)
 
 add_library(MergeChannelsModule SHARED modules/improc/MergeChannelsModule.cpp)
 qt5_use_modules(MergeChannelsModule Core ) #QtCore is needed for <QPlugin>
-target_link_libraries(MergeChannelsModule opencv_core opencv_imgproc ModuleBase)
+target_link_libraries(MergeChannelsModule opencv_core opencv_imgproc uipf-ModuleBase)
 
 
 # Data structures
 add_library(SelectListItemModule SHARED modules/data/SelectListItemModule.cpp)
 qt5_use_modules(SelectListItemModule Core ) #QtCore is needed for <QPlugin>
-target_link_libraries(SelectListItemModule opencv_core opencv_imgproc ModuleBase)
+target_link_libraries(SelectListItemModule opencv_core opencv_imgproc uipf-ModuleBase)
 
 add_library(AddListItemModule SHARED modules/data/AddListItemModule.cpp)
 qt5_use_modules(AddListItemModule Core ) #QtCore is needed for <QPlugin>
-target_link_libraries(AddListItemModule opencv_core opencv_imgproc ModuleBase)
+target_link_libraries(AddListItemModule opencv_core opencv_imgproc uipf-ModuleBase)
+
 
 
 #
-# external dependencies
-# http://www.cmake.org/cmake/help/v2.8.8/cmake.html#module%3aExternalProject
+# installation targets
 #
 
-
-# yaml-cpp
-ExternalProject_Add(YAML_CPP
-	GIT_REPOSITORY https://github.com/jbeder/yaml-cpp.git
-	GIT_TAG release-0.5.2
-	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp -DBUILD_SHARED_LIBS=YES
+install(TARGETS uipf uipf-gui uipf-ModuleBase
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
 )
-include_directories(${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp/include)
-FIND_LIBRARY(YAML_CPP_LIBRARY yaml-cpp ${CMAKE_CURRENT_BINARY_DIR}/yaml-cpp/lib)
+install(TARGETS
+			AddListItemModule
+			ConvolutionModule
+			DummyModule
+			GaussianModule
+			LoadImageModule
+			LongRunningDummyModule
+			MergeChannelsModule
+			SelectListItemModule
+			ShowImageListModule
+			ShowImageModule
+			SplitChannelsModule
+			StoreImageModule
 
-add_dependencies(uipf-framework YAML_CPP)
-add_dependencies(uipf-framework YAML_CPP_LIBRARY)
+        LIBRARY DESTINATION lib/uipf
+)
 

--- a/code/framework/Configuration.cpp
+++ b/code/framework/Configuration.cpp
@@ -381,7 +381,8 @@ void Configuration::print() {
 
 	string out = getYAML();
 
-	LOG_I(out);
+	cout << out;
+	cout << endl;
 }
 
 // stores the current module configuration in a yaml file

--- a/code/framework/DataManager.hpp
+++ b/code/framework/DataManager.hpp
@@ -117,7 +117,7 @@ inline int DataManager::getParam( const std::string& strName, int defaultValue) 
 {
 	if (params_.find(strName) != params_.end() && !params_[strName].empty())
 	{
-		return atoi(params_[strName].c_str());
+		return std::stoi(params_[strName]);
 	}
 	else
 	{
@@ -130,7 +130,13 @@ inline float DataManager::getParam(const std::string& strName, float defaultValu
 {
 	if (params_.find(strName) != params_.end() && !params_[strName].empty())
 	{
-		return atof(params_[strName].c_str());
+		// std::stof() is locale aware, meaning params are not portable between platforms
+		// the following is a locale independend stof():
+		float value = defaultValue;
+		std::istringstream istr(params_[strName]);
+		istr.imbue(std::locale("C"));
+		istr >> value;
+		return value;
 	}
 	else
 	{
@@ -143,7 +149,13 @@ inline double DataManager::getParam( const std::string& strName, double defaultV
 {
 	if (params_.find(strName) != params_.end() && !params_[strName].empty())
 	{
-		return atof(params_[strName].c_str());
+		// std::stod() is locale aware, meaning params are not portable between platforms
+		// the following is a locale independend stod():
+		double value = defaultValue;
+		std::istringstream istr(params_[strName]);
+		istr.imbue(std::locale("C"));
+		istr >> value;
+		return value;
 	}
 	else
 	{

--- a/code/framework/Logger.cpp
+++ b/code/framework/Logger.cpp
@@ -21,7 +21,10 @@ Logger* Logger::instance()
 void Logger::Warn(const std::string& strMessage)
 {
 	std::stringstream output;
-	output << "[WARNING] " << strMessage << std::endl;
+
+	// output in yellow using ANSI codes http://en.wikipedia.org/wiki/ANSI_escape_code
+	output << "\033[1;33m[WARNING] " << strMessage << "\033[0m" << std::endl;
+
 	print(output);
 
 	//send signal to GUI
@@ -32,8 +35,9 @@ void Logger::Error(const std::string& strMessage)
 {
 	std::stringstream output;
 
-	output << "\033[1;31m[ERROR] " << strMessage << "\033[0m" << std::endl;//output in red using ANSI codes (linux only):
-									       //http://en.wikipedia.org/wiki/ANSI_escape_code
+	// output in red using ANSI codes http://en.wikipedia.org/wiki/ANSI_escape_code
+	output << "\033[1;31m[ERROR] " << strMessage << "\033[0m" << std::endl;
+
 	print(output);
 
 	//send signal to GUI
@@ -43,7 +47,8 @@ void Logger::Error(const std::string& strMessage)
 void Logger::Info(const std::string& strMessage)
 {
 	std::stringstream output;
-	output << "[INFO] " << strMessage << std::endl;
+	// output in bold (more visible than normal stdout) using ANSI codes http://en.wikipedia.org/wiki/ANSI_escape_code
+	output << "\033[1m[INFO] " << strMessage << "\033[0m" << std::endl;
 	print(output);
 
 	//send signal to GUI

--- a/code/framework/ModuleManager.cpp
+++ b/code/framework/ModuleManager.cpp
@@ -232,6 +232,9 @@ void ModuleManager::initModules()
 
 		foreach (QString fileName, pluginsDir.entryList(QDir::Files))
 		{
+			if (!fileName.endsWith(".so")) {
+				continue;
+			}
 			QPluginLoader* loader = new QPluginLoader(pluginsDir.absoluteFilePath(fileName));
 			QObject *plugin = loader->instance();
 			if (plugin) {
@@ -262,6 +265,9 @@ std::vector<std::string> ModuleManager::loadPluginPathConfig()
 	configPath.push_back("~/.uipf-modules.yaml");
 
 	vector<std::string> pluginPaths;
+	// also add two default search paths
+	pluginPaths.push_back("/usr/lib/uipf");
+	pluginPaths.push_back("/usr/local/lib/uipf");
 
 	// search for module path configuration files
 	for(auto cp = configPath.cbegin(); cp != configPath.end(); ++cp) {
@@ -284,8 +290,8 @@ std::vector<std::string> ModuleManager::loadPluginPathConfig()
 		catch(...)
 		{
 		}
+
 	}
-	pluginPaths.push_back(".");
 
 	return pluginPaths;
 }

--- a/code/framework/ModuleManager.cpp
+++ b/code/framework/ModuleManager.cpp
@@ -146,15 +146,15 @@ void ModuleManager::run(Configuration config){
 			DataManager dataMnrg(inputs, proSt.params, *outputs);
 			module->run(dataMnrg);
 
-		} catch (ErrorException& e) {
+		} catch (const ErrorException& e) {
 			GUIEventDispatcher::instance()->triggerSelectSingleNodeInGraphView(proSt.name,gui::ERROR,false);
 			LOG_E( string("Error: ") + e.what() );
 			break;
-		} catch (InvalidConfigException& e) {
+		} catch (const InvalidConfigException& e) {
 			GUIEventDispatcher::instance()->triggerSelectSingleNodeInGraphView(proSt.name,gui::ERROR,false);
 			LOG_E( string("Invalid config: ") + e.what() );
 			break;
-		} catch (std::exception& e) {
+		} catch (const std::exception& e) {
 			GUIEventDispatcher::instance()->triggerSelectSingleNodeInGraphView(proSt.name,gui::ERROR,false);
 			LOG_E( string("Error: module threw exception: ") + e.what() );
 			break;

--- a/code/framework/ModuleManager.cpp
+++ b/code/framework/ModuleManager.cpp
@@ -7,6 +7,8 @@
 #include <QString>
 #include <string>
 
+#include "yaml-cpp/yaml.h"
+
 #include "Logger.hpp"
 #include "ModuleBase.hpp"
 #include "ModuleInterface.hpp"
@@ -222,21 +224,70 @@ void ModuleManager::run(Configuration config){
 // that can be used later to instantiate the module
 void ModuleManager::initModules()
 {
-	QDir pluginsDir = QDir(qApp->applicationDirPath());
+	vector<std::string> pluginPaths = loadPluginPathConfig();
 
-	foreach (QString fileName, pluginsDir.entryList(QDir::Files))
-	{
-		QPluginLoader* loader = new QPluginLoader(pluginsDir.absoluteFilePath(fileName));
-		QObject *plugin = loader->instance();
-		if (plugin) {
-			Logger::instance()->Info("found module: " + fileName.toStdString());
-			ModuleInterface* iModule = qobject_cast<ModuleInterface* >(plugin);
+	for(auto path = pluginPaths.cbegin(); path != pluginPaths.end(); ++path) {
 
-			plugins_.insert( std::pair<std::string, QPluginLoader*>(iModule->name(), loader) );
-			delete iModule;
+		QDir pluginsDir = QDir(QString(path->c_str()));
+
+		foreach (QString fileName, pluginsDir.entryList(QDir::Files))
+		{
+			QPluginLoader* loader = new QPluginLoader(pluginsDir.absoluteFilePath(fileName));
+			QObject *plugin = loader->instance();
+			if (plugin) {
+				//Logger::instance()->Info("found module: " + fileName.toStdString());
+				ModuleInterface* iModule = qobject_cast<ModuleInterface* >(plugin);
+
+				plugins_.insert( std::pair<std::string, QPluginLoader*>(iModule->name(), loader) );
+				delete iModule;
+			} else {
+				LOG_E(loader->errorString().toStdString());
+			}
+
 		}
 
 	}
+
+}
+
+std::vector<std::string> ModuleManager::loadPluginPathConfig()
+{
+	// search path for uipf config files
+	vector<std::string> configPath;
+	// search in current working directory
+	configPath.push_back("./modules.yaml");
+	// search in /etc
+	configPath.push_back("/etc/uipf/modules.yaml");
+	// search in home directory of the user
+	configPath.push_back("~/.uipf-modules.yaml");
+
+	vector<std::string> pluginPaths;
+
+	// search for module path configuration files
+	for(auto cp = configPath.cbegin(); cp != configPath.end(); ++cp) {
+
+		try
+		{
+			// try to load yaml file
+			YAML::Node config = YAML::LoadFile(*cp);
+
+			// yaml file must be a sequence of module paths to search for
+			if (!config.IsSequence())
+				continue;
+
+			// create a ProcessingStep object from each config element
+			YAML::const_iterator it = config.begin();
+			for ( ; it != config.end(); ++it) {
+				pluginPaths.push_back(it->as<string>());
+			}
+		}
+		catch(...)
+		{
+		}
+	}
+	pluginPaths.push_back(".");
+
+	return pluginPaths;
 }
 
 // returns a list of all loaded modules names

--- a/code/framework/ModuleManager.hpp
+++ b/code/framework/ModuleManager.hpp
@@ -49,6 +49,8 @@ class ModuleManager{
 		// instantiate a named module
 		ModuleInterface* loadModule(const std::string& name);
 
+		std::vector<std::string> loadPluginPathConfig();
+
 		// check which modules exist and populate  plugins_
 		void initModules();
 

--- a/code/framework/types/Bool.cpp
+++ b/code/framework/types/Bool.cpp
@@ -3,7 +3,7 @@
 using namespace uipf;
 
 // returns the value of the boolean
-bool Bool::getContent(){
+bool Bool::getContent() const {
 	return b_;
 }
 
@@ -11,11 +11,11 @@ bool Bool::getContent(){
 /*
 b	new boolean value
 */
-void Bool::setContent(bool b){
+void Bool::setContent(bool b) {
 	b_ = b;
 }
 
 // returns the data type of this data object: in this case: BOOL
-Type Bool::getType(){
+Type Bool::getType() const {
 	return BOOL;
 }

--- a/code/framework/types/Bool.hpp
+++ b/code/framework/types/Bool.hpp
@@ -23,13 +23,13 @@ class Bool : public Data {
 		~Bool(void){};
 
 		// returns the value of the boolean
-		bool getContent();
+		bool getContent() const;
 
 		// sets the value of the boolean
 		void setContent(bool);
 
 		// returns the data type of this data object: in this case: BOOL
-		Type getType() override;
+		Type getType() const override;
 
 	private:
 		// value of the boolean

--- a/code/framework/types/Bool.hpp
+++ b/code/framework/types/Bool.hpp
@@ -13,8 +13,12 @@ class Bool : public Data {
 		typedef const SMARTPOINTER<Bool> c_ptr;
 
 	public:
+		// default constructor
+		Bool() : b_(false) {};
 		// constructor
 		Bool(bool b) : b_(b) {};
+		// copy constructor
+		Bool(const Bool& b) : b_(b.b_) {};
 		// destructor
 		~Bool(void){};
 

--- a/code/framework/types/Data.hpp
+++ b/code/framework/types/Data.hpp
@@ -46,7 +46,7 @@ class Data {
 
 		// returns the data type of this data object
 		// this is a virtual method, which has to be overwritten in the class, which derives of Data
-		virtual Type getType() = 0;
+		virtual Type getType() const = 0;
 
 };
 

--- a/code/framework/types/Float.cpp
+++ b/code/framework/types/Float.cpp
@@ -3,7 +3,7 @@
 using namespace uipf;
 
 // returns the value of the float
-float Float::getContent(){
+float Float::getContent() const {
 	return f_;
 }
 
@@ -11,11 +11,11 @@ float Float::getContent(){
 /*
 f	new float value
 */
-void Float::setContent(float f){
+void Float::setContent(float f) {
 	f_ = f;
 }
 
 // returns the data type of this data object: in this case: FLOAT
-Type Float::getType(){
+Type Float::getType() const {
 	return FLOAT;
 }

--- a/code/framework/types/Float.hpp
+++ b/code/framework/types/Float.hpp
@@ -22,13 +22,13 @@ class Float : public Data {
 		~Float(void){};
 
 		// returns the value of the float
-		float getContent();
+		float getContent() const;
 
 		// sets the value of the float
 		void setContent(float);
 
 		// returns the data type of this data object: in this case: FLOAT
-		Type getType() override;
+		Type getType() const override;
 
 	private:
 		// value of the float

--- a/code/framework/types/Float.hpp
+++ b/code/framework/types/Float.hpp
@@ -12,8 +12,12 @@ class Float : public Data {
 			typedef SMARTPOINTER<Float> ptr;
 			typedef const SMARTPOINTER<Float> c_ptr;
 	public:
+		// default constructor
+		Float() : f_(0.0) {};
 		// constructor
 		Float(float f) : f_(f) {};
+		// copy constructor
+		Float(const Float& f) : f_(f.f_) {};
 		// destructor
 		~Float(void){};
 

--- a/code/framework/types/Integer.cpp
+++ b/code/framework/types/Integer.cpp
@@ -3,7 +3,7 @@
 using namespace uipf;
 
 // returns the value of the integer
-int Integer::getContent(){
+int Integer::getContent() const {
 	return i_;
 }
 
@@ -11,11 +11,11 @@ int Integer::getContent(){
 /*
 i	new integer value
 */
-void Integer::setContent(int i){
+void Integer::setContent(int i) {
 	i_ = i;
 }
 
 // returns the data type of this data object: in this case: INTEGER
-Type Integer::getType(){
+Type Integer::getType() const {
 	return INTEGER;
 }

--- a/code/framework/types/Integer.hpp
+++ b/code/framework/types/Integer.hpp
@@ -23,13 +23,13 @@ class Integer : public Data {
 		~Integer(void){};
 
 		// returns the value of the integer
-		int getContent();
+		int getContent() const;
 
 		// sets the value of the integer
 		void setContent(int);
 
 		// returns the data type of this data object: in this case: INTEGER
-		Type getType() override;
+		Type getType() const override;
 
 	private:
 		// value of the integer

--- a/code/framework/types/Integer.hpp
+++ b/code/framework/types/Integer.hpp
@@ -13,8 +13,12 @@ class Integer : public Data {
 		typedef const SMARTPOINTER<Integer> c_ptr;
 
 	public:
+		// default constructor
+		Integer() : i_(0) {};
 		// constructor
 		Integer(int i) : i_(i) {};
+		// copy constructor
+		Integer(const Integer& i) : i_(i.i_) {};
 		// destructor
 		~Integer(void){};
 

--- a/code/framework/types/List.hpp
+++ b/code/framework/types/List.hpp
@@ -23,7 +23,7 @@ class List : public Data {
 		~List(void){};
 
 		// returns the content of the list
-		std::list<typename T::ptr> getContent();
+		std::list<typename T::ptr> getContent() const;
 
 		// sets the content of the list
 		void setContent(std::list<typename T::ptr>);
@@ -39,7 +39,7 @@ class List : public Data {
 		void addItem(typename T::ptr item);
 
 		// returns the data type of this data object: in this case: LIST
-		Type getType() override;
+		Type getType() const override;
 
 	private:
 		// content of the list
@@ -51,7 +51,7 @@ class List : public Data {
 
 // returns the content of the list
 template <typename T>
-std::list<typename T::ptr> List<T>::getContent(){
+std::list<typename T::ptr> List<T>::getContent() const {
 	return list_;
 }
 
@@ -103,19 +103,19 @@ void List<T>::addItem(typename T::ptr item) {
 
 // returns the data type of this data object: in this case: LIST
 template <>
-inline Type List<String>::getType() { return STRING_LIST; }
+inline Type List<String>::getType() const { return STRING_LIST; }
 
 template <>
-inline Type List<Integer>::getType() { return INTEGER_LIST; }
+inline Type List<Integer>::getType() const { return INTEGER_LIST; }
 
 template <>
-inline Type List<Float>::getType() { return FLOAT_LIST; }
+inline Type List<Float>::getType() const { return FLOAT_LIST; }
 
 template <>
-inline Type List<Bool>::getType() { return BOOL_LIST; }
+inline Type List<Bool>::getType() const { return BOOL_LIST; }
 
 template <>
-inline Type List<Matrix>::getType() { return MATRIX_LIST; }
+inline Type List<Matrix>::getType() const { return MATRIX_LIST; }
 
 
 

--- a/code/framework/types/Matrix.cpp
+++ b/code/framework/types/Matrix.cpp
@@ -21,6 +21,6 @@ void Matrix::setContent(Mat& m){
 }
 
 // returns the data type of this data object: in this case: MATRIX
-Type Matrix::getType() {
+Type Matrix::getType() const {
 	return MATRIX;
 }

--- a/code/framework/types/Matrix.cpp
+++ b/code/framework/types/Matrix.cpp
@@ -3,14 +3,6 @@
 using namespace cv;
 using namespace uipf;
 
-// constructor
-/*
-oMat	the content of the matrix	(matrix_ = oMat)
-*/
-Matrix::Matrix(Mat& oMat) :matrix_(oMat){
-}
-
-
 // get content (returns a cloned version of Mat by default)
 // this is due to prevent overwriting accidentally
 Mat Matrix::getContent(bool bAutoClone /*= true*/) const{

--- a/code/framework/types/Matrix.hpp
+++ b/code/framework/types/Matrix.hpp
@@ -12,8 +12,12 @@ class Matrix : public Data {
 		typedef const SMARTPOINTER<Matrix> c_ptr;
 
 	public:
+		// default constructor
+		Matrix() {}
 		// constructor
-		Matrix(cv::Mat&);
+		Matrix(cv::Mat& mat): matrix_(mat) {}
+		// copy constructor
+		Matrix(const Matrix& mat): matrix_(mat.matrix_.clone()) {}
 		// destructor
 		~Matrix(void){};
 

--- a/code/framework/types/Matrix.hpp
+++ b/code/framework/types/Matrix.hpp
@@ -29,7 +29,7 @@ class Matrix : public Data {
 		void setContent(cv::Mat&);
 
 		// returns the data type of this data object: in this case: MATRIX
-		Type getType() override;
+		Type getType() const override;
 
 	private:
 		// content of the matrix

--- a/code/framework/types/String.cpp
+++ b/code/framework/types/String.cpp
@@ -4,7 +4,7 @@ using namespace std;
 using namespace uipf;
 
 // returns the value of the string
-string String::getContent(){
+string String::getContent() const {
 	return str_;
 }
 
@@ -12,11 +12,11 @@ string String::getContent(){
 /*
 str		new string value
 */
-void String::setContent(string str){
+void String::setContent(string str) {
 	str_ = str;
 }
 
 // returns the data type of this data object: in this case: STRING
-Type String::getType(){
+Type String::getType() const {
 	return STRING;
 }

--- a/code/framework/types/String.hpp
+++ b/code/framework/types/String.hpp
@@ -24,13 +24,13 @@ class String : public Data {
 		~String(void){};
 
 		// returns the value of the string
-		std::string getContent();
+		std::string getContent() const;
 
 		// sets the value of the string
 		void setContent(std::string);
 
 		// returns the data type of this data object: in this case: STRING
-		Type getType() override;
+		Type getType() const override;
 
 	private:
 		// value of the string

--- a/code/framework/types/String.hpp
+++ b/code/framework/types/String.hpp
@@ -14,8 +14,12 @@ class String : public Data {
 		typedef const SMARTPOINTER<String> c_ptr;
 
 	public:
+		// default constructor
+		String() {};
 		// constructor
 		String(std::string s) : str_(s) {};
+		// copy constructor
+		String(const String& s) : str_(s.str_) {};
 		// destructor
 		~String(void){};
 

--- a/code/gui/MainWindow.cpp
+++ b/code/gui/MainWindow.cpp
@@ -17,6 +17,8 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 #include <QDebug>
+#include <libgen.h>
+#include <unistd.h>
 
 #include "MainWindow.hpp"
 #include "ImageWindow.hpp"
@@ -235,6 +237,12 @@ void MainWindow::loadDataFlow(string filename)
     setWindowTitle(tr((currentFileName + string(" - ") + WINDOW_TITLE).c_str()));
 
 	conf_.load(currentFileName);
+
+	// set current working directory to directory of the .yaml file
+	char bFileName[currentFileName.length() + 1];
+	std::size_t length = currentFileName.copy(bFileName, currentFileName.length());
+	bFileName[length]='\0';
+	chdir(dirname(bFileName));
 
     // only for debug, print the loaded config
 	//conf_.print();

--- a/code/gui/MainWindow.cpp
+++ b/code/gui/MainWindow.cpp
@@ -238,7 +238,7 @@ void MainWindow::loadDataFlow(string filename)
 
 	conf_.load(currentFileName);
 
-	// set current working directory to directory of the .yaml file
+	// set current working directory to directory of the .yaml file to make relative paths work
 	char bFileName[currentFileName.length() + 1];
 	std::size_t length = currentFileName.copy(bFileName, currentFileName.length());
 	bFileName[length]='\0';

--- a/code/main-console.cpp
+++ b/code/main-console.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <string>
+#include <libgen.h>
 #include <QCoreApplication>
+
 #include "framework/ModuleManager.hpp"
 #include "framework/Configuration.hpp"
 #include "framework/Utils.hpp"
@@ -87,6 +89,11 @@ int main(int argc, char** argv){
 		string configFileName = argv[2];
 		conf.load(configFileName);
 
+		// set current working directory to directory of the .yaml file to make relative paths work
+		char bFileName[configFileName.length() + 1];
+		std::size_t length = configFileName.copy(bFileName, configFileName.length());
+		bFileName[length]='\0';
+		chdir(dirname(bFileName));
 
 	} else if (vm.count("list")){
 	// list all available modules

--- a/code/main-console.cpp
+++ b/code/main-console.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <string>
-#include <QApplication>
+#include <QCoreApplication>
 #include "framework/ModuleManager.hpp"
 #include "framework/Configuration.hpp"
 #include "framework/Utils.hpp"
@@ -74,7 +74,7 @@ int main(int argc, char** argv){
 	}
 
 	// used by the module manager to access Qt components, TODO maybe move to module manager?
-	QApplication app (argc,argv);
+	QCoreApplication app (argc,argv);
 
 	ModuleManager mm;
 	Configuration conf;

--- a/code/uipf-gui.desktop
+++ b/code/uipf-gui.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=UIPF GUI
+Comment=Unified Image Processing Framework (GUI)
+Exec=uipf-gui %f
+Categories=Graphics;Development;Science
+Terminal=false
+MimeType=application/x-yaml;

--- a/code/uipf.desktop
+++ b/code/uipf.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Execute UIPF Processing Chain
+Comment=Unified Image Processing Framework (Terminal)
+Exec=uipf -c %f
+Categories=Graphics;Development;Science
+Terminal=true
+MimeType=application/x-yaml;
+NoDisplay=true

--- a/doc/extending-modules.md
+++ b/doc/extending-modules.md
@@ -5,9 +5,9 @@ This document describes how custom Modules can be built for the uipf.
 
 ## What are Modules?
 
-Modules are precompiled extensions that:
+Modules are precompiled extensions/plugins that:
 
- - encapsulate functionality which can be used in processingsteps
+ - encapsulate functionality which can be used in processing steps
  - are binary files, shareable without sourcecode (QTPlugin)
  - implement a simple interface
  - can include own libs as they need them
@@ -77,7 +77,126 @@ Now you can build your new module with `make` and use it in the GUI as well as t
 
 ### Compiling your module
 
-TBD
+If your module is not generic enough to make it part of UIPF itself, you can
+will likely be working in a separte directory when developing it. 
+
+#### Compiling with CMake
+
+Assuming the following file structure in your module:
+
+- `src/ExampleModule.hpp`:
+  
+  ```cpp
+  #include <uipf/framework/ModuleBase.hpp>
+  
+  class ExampleModule :  public QObject, uipf::ModuleBase
+  {
+  	Q_OBJECT
+  	Q_PLUGIN_METADATA(IID "org.tu-berlin.uipf.ExampleModule" )
+  	Q_INTERFACES(uipf::ModuleInterface)
+  
+  public:
+  	// constructor tells ModuleBase our name so we don't need to implement name()
+  	ExampleModule(void) : uipf::ModuleBase("example"){};
+  
+  	// destructor needs to be virtual otherwise it not called due polymorphism
+  	virtual ~ExampleModule(void){};
+  
+  	void run( uipf::DataManager& data ) const Q_DECL_OVERRIDE;
+  
+  	uipf::MetaData getMetaData() const Q_DECL_OVERRIDE;
+  };
+  ```
+
+- `src/ExampleModule.cpp`:
+
+  ```cpp
+  #include "ExampleModule.hpp"
+  
+  using namespace uipf;
+  
+  void ExampleModule::run( DataManager& data) const
+  {
+  	// implement module functionality here working on input/output data and parameters using DataManager
+  }
+  
+  MetaData ExampleModule::getMetaData() const
+  {
+  	using namespace std;
+  
+  	map<string, DataDescription> input = {
+  		// describe inputs here
+  	};
+  	map<string, DataDescription> output = {
+  		// describe outputs here
+  	};
+  	map<string, ParamDescription> params = {
+  		// describe parameters here
+  	};
+  
+  	return MetaData(
+  			"A minimal Example module",
+  			"pathSfM",
+  			input,
+  			output,
+  			params
+  	);
+  }
+  ```
+
+To compile your module with [cmake](https://cmake.org/), create the following `CMakelists.txt` file in the root folder:
+
+```cmake
+cmake_minimum_required(VERSION 2.8.8)
+project(example)
+
+set(CMAKE_CXX_STANDARD 11)
+
+# make Qt work
+set(CMAKE_AUTOMOC ON)
+# make sure MOC will find UIPF
+SET(CMAKE_AUTOMOC_MOC_OPTIONS
+-I/usr/local/include
+)
+# find Qt library for QPlugin
+find_package(Qt5Widgets REQUIRED)
+find_library(ModuleBase uipf-ModuleBase)
+
+# build example module
+add_library(ExampleModule SHARED src/ExampleModule.cpp)
+qt5_use_modules(ExampleModule Core) #QtCore is needed for <QPlugin>
+target_link_libraries(ExampleModule ${ModuleBase})
+```
+
+You can now compile your module using the following commands:
+
+    mkdir build && cd build
+    cmake ..
+    make
+    
+This will create a `libExampleModule.so` file in the current directory, which is the module binary file.
+
+#### Configure UIPF to load the module
+
+When started, UIPF will search for a module configuration file in the following locations:
+
+- `/usr/lib/uipf`
+- `/usr/local/lib/uipf`
+- Additionally to the above two paths, you can configure more
+  search paths by creating a configuration file.
+  The configuration file can be located in the following locations:
+  
+  - current working directory (`./modules.yaml`)
+  - your home directory (`~/.uipf-modules.yaml`)
+  - system-wide configuration (`/etc/uipf/modules.yaml`)
+  
+  The configuration file should contain a [YAML](http://www.yaml.org/) list of paths to search for modules, e.g.:
+  
+  ```yaml
+  - ~/project1/uipf-modules/build
+  - ~/project2/uipf-modules/build
+  ```
+
 
 ### Logging and error handling
 
@@ -93,7 +212,7 @@ LOG_W(
 
 Error handling:
 
-To abort the run of the module you can throw any exception. THere is one exception class provided which can carry a
+To abort the run of the module you can throw any exception. There is one exception class provided which can carry a
 message:
 `throw InvalidConfigException("the object mesh is invalid");`
 

--- a/doc/extending-modules.md
+++ b/doc/extending-modules.md
@@ -15,6 +15,8 @@ Modules are precompiled extensions that:
  
 ## How can I write a new Module?
 
+### Introduction
+
 To write your own Module you basically have to do the following steps:
  
 1. Create a c++ class that derives from ModuleInterface. This mainly requires three Methods:
@@ -72,3 +74,29 @@ To write your own Module you basically have to do the following steps:
    Of course you don't need to use the `CMakeList.txt` of the whole project. You may create your own one just for your Module.
 
 Now you can build your new module with `make` and use it in the GUI as well as the console.
+
+### Compiling your module
+
+TBD
+
+### Logging and error handling
+
+TBD
+
+Logging makros
+
+```
+LOG_I(
+LOG_E(
+LOG_W(
+```
+
+Error handling:
+
+To abort the run of the module you can throw any exception. THere is one exception class provided which can carry a
+message:
+`throw InvalidConfigException("the object mesh is invalid");`
+
+
+
+


### PR DESCRIPTION
currently it is not possible to install uipf on a system with `make install` and also other modules which are not directly located in uipf development directory can not be used.
This pull request adds some changes to improve the situation. It is work in progress and should not be merged.
- [x] Add install targets ot CMakeLists.txt
- [x] Change ModuleManager to be able to load modules from different locations
- [ ] open bug (opencv waitkey does not work in console module):
  
  ```
  uipf: symbol lookup error: /Code/build/libVisualizationModule.so: undefined symbol: _ZN2cv7waitKeyEi
  ```
- [x] fix chdir() issue for console too (to make relative paths in yaml files work)
- [x] Add Documentation on how to load modules
- [x] Add Documentation on how to compile external modules
